### PR TITLE
Adding user.variant and user.script to excludes

### DIFF
--- a/src/main/java/org/nanoko/playframework/mojo/AbstractPlay2Mojo.java
+++ b/src/main/java/org/nanoko/playframework/mojo/AbstractPlay2Mojo.java
@@ -96,6 +96,8 @@ public abstract class AbstractPlay2Mojo extends AbstractMojo {
             "socksNonProxyHosts",
             "ftp.nonProxyHosts",
             "sun.cpu.isalist",
+            "user.variant",
+            "user.script",
             // List related to Maven source
             "maven.home",
             "guice.disable.misplaced.annotation.check",


### PR DESCRIPTION
On windows 8.1 and Java 8 the following command is executed which is not valid (pay attention to the part "-Duser.script"="-Dsun.desktop" "windows")
    "c:\Program Files\Java\jdk1.8.0_20\\bin\java.exe"   -XX:MetaspaceSize=64M -XX:MaxMetaspaceSize=256M    "-Dactivator.home=//c:/Inzenjerija/activator-1.2.8-minimal" -jar "c:\Inzenjerija\activator-1.2.8-minimal\activator-launch-1.2.8.jar"  "-Duser.script"="-Dsun.desktop" "windows" "-Dsun.stderr.encoding"="cp850" "-Dsun.stdout.encoding"="cp850" "-Duser.variant"="test"

As an easy fix, I added these often empty system props into