### PR TITLE
Added "fullClean" option + copy web-assets into target

### DIFF
--- a/src/main/java/org/nanoko/playframework/mojo/Play2CleanMojo.java
+++ b/src/main/java/org/nanoko/playframework/mojo/Play2CleanMojo.java
@@ -54,6 +54,15 @@ public class Play2CleanMojo
      * @parameter default-value="true"
      */
     private boolean cleanLibFolder = true;
+    
+    /**
+     * Set to false to avoid cleaning 
+     * the incremetal compilation artifacts from play.
+     * for some reason it impacts the compilation from time to time and is not cleaned using the "clean" command
+     *
+     * @parameter default-value="false"
+     */
+    private boolean fullClean = false;
 
     public void execute()
             throws MojoExecutionException {
@@ -101,6 +110,26 @@ public class Play2CleanMojo
             }
         } else {
             getLog().debug("'logs' directory not found");
+        }
+        
+        //Also delete the target & project folder in project (this contains some code generateed incrementally by play)
+        if(fullClean){
+            File incrementalCompilationInProjectTarget = new File(project.getBasedir(), "project/target");
+            File incrementalCompilationInProjectProject = new File(project.getBasedir(), "project/project");
+            if(incrementalCompilationInProjectTarget.exists()){
+                try {
+                    FileUtils.deleteDirectory(incrementalCompilationInProjectTarget);
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Can't delete the project generated code content", e);
+                }
+            }
+            if(incrementalCompilationInProjectProject.exists()){
+                try {
+                    FileUtils.deleteDirectory(incrementalCompilationInProjectProject);
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Can't delete the project generated code content", e);
+                }
+            }
         }
 
         // Also delete the lib directory if set

--- a/src/main/java/org/nanoko/playframework/mojo/Play2PackageMojo.java
+++ b/src/main/java/org/nanoko/playframework/mojo/Play2PackageMojo.java
@@ -123,8 +123,8 @@ public class Play2PackageMojo
             packageDistribution();
             dist = moveDistributionArtifactToTarget();
 
-            // The javadoc and source files are created during the distribution construction.
-            moveJavadocAndSourcesArtifactsToTarget();
+            // The javadoc, source and web-assets files are created during the distribution construction.
+            moveOtherArtifactsToTarget();
 
             if (!additionalFiles.isEmpty()) {
                 packageAdditionalFiles(additionalFiles, dist);
@@ -331,9 +331,10 @@ public class Play2PackageMojo
         return out;
     }
 
-    private void moveJavadocAndSourcesArtifactsToTarget() throws MojoExecutionException {
+    private void moveOtherArtifactsToTarget() throws MojoExecutionException {
         File sourceJar = null;
         File javadocJar = null;
+        File webAssetsJar = null;
 
         File target = getBuildDirectory();
         File[] files = FileUtils.convertFileCollectionToFileArray(
@@ -345,6 +346,8 @@ public class Play2PackageMojo
                 sourceJar = file;
             } else if (file.getName().endsWith("-javadoc.jar")) {
                 javadocJar = file;
+            } else if(file.getName().endsWith("-web-assets.jar")){
+                webAssetsJar = file;
             }
         }
         try {
@@ -359,8 +362,14 @@ public class Play2PackageMojo
                 File out = new File(target, project.getBuild().getFinalName() + "-javadoc.jar");
                 FileUtils.copyFile(javadocJar, out);
             }
+            
+            if (webAssetsJar != null) {
+                getLog().info("Artifact containing the web assets found - copying to target");
+                File out = new File(target, project.getBuild().getFinalName() + "-web-assets.jar");
+                FileUtils.copyFile(webAssetsJar, out);
+            }
         } catch (IOException e) {
-            throw new MojoExecutionException("Can't copy the javadoc and sources file to the target folder", e);
+            throw new MojoExecutionException("Can't copy the javadoc, sources or web-assets files to the target folder", e);
         }
     }
 


### PR DESCRIPTION
Hello, I added a "fullClean" option to the CleanMojo.
It cleans some code which is generated by play into the "project" folder (in the past there was a "full-clean" option which disapeared with activator). For a real clean these folders should be deleted (however the option is defaulted to "false").

I also modified the PackageMojo in order to copy the "web-assets" to the target folder.
It can be an option to also propose to merge the web-assets with the application jar (today I am doing it after Nanoko with an ANT task).