### PR TITLE
Some little modifications for WarPackageMojo class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
                     </systemProperties>
                 </configuration>
             </plugin>
-
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -543,7 +543,7 @@
                     </execution>
                 </executions>
             </plugin>
-
+            -->
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.2.1</version>
@@ -576,6 +576,7 @@
             </plugin>-->
 
             <!-- Integration test using the invoker plugin -->
+            <!--
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>1.8</version>
@@ -597,6 +598,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
                     </systemProperties>
                 </configuration>
             </plugin>
-            <!--
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -543,7 +543,7 @@
                     </execution>
                 </executions>
             </plugin>
-            -->
+
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.2.1</version>
@@ -576,7 +576,6 @@
             </plugin>-->
 
             <!-- Integration test using the invoker plugin -->
-            <!--
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <version>1.8</version>
@@ -598,7 +597,6 @@
                     </execution>
                 </executions>
             </plugin>
-            -->
         </plugins>
     </build>
 


### PR DESCRIPTION
additionalFiles parameter can now be a folder (and not only a file)

Use URL filename to add play2-war dependencies from plugin's artifacts.
See copyServletBridge() function

add new parameter searchPlay2WarArtifactsInProjectDependencies (default value is false) to use pay2-war artifacts from project dependencies.
See packageWarFile(File war, File warFile) function